### PR TITLE
chore: bump Go to 1.25.8 to fix CVE-2026-25679, CVE-2026-27142

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.25 as builder
+FROM docker.io/library/golang:1.25.8 as builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.25.7
+go 1.25.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Summary

Bumps Go toolchain from 1.25.7 to 1.25.8 to fix two stdlib CVEs:

- **CVE-2026-25679** (HIGH): stdlib v1.25.7 → fixed in v1.25.8+
- **CVE-2026-27142** (MEDIUM): stdlib v1.25.7 → fixed in v1.25.8+

## Changes

- `build/Dockerfile`: Updated base image from `golang:1.25` to `golang:1.25.8`
- `go.mod`: Updated Go directive from `go 1.25.7` to `go 1.25.8`

## Image

The new Docker image `tetrate/eck-operator:2.11.1-tetrate-v12` has been built and published via the [build-eck-operator workflow](https://github.com/tetrateio/skywalking-fork-sync/actions/runs/23369566823).

This image will be used in:
- `master` branch of the monorepo
- `release-1.11.x` branch of the monorepo