### PR TITLE
cves: bump Go to 1.26.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.25 as builder
+FROM docker.io/library/golang:1.25.8 as builder
 
 ARG VERSION
 ARG SHA1

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.25.8 as builder
+FROM docker.io/library/golang:1.26.1 as builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.25.7
+go 1.25.8
 
 require (
 	dario.cat/mergo v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.25.8
+go 1.26.1
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Summary

Upgrade Go from 1.25.7 to 1.26.1 to fix three Go stdlib CVEs.

- Update go.mod: go 1.25.7 → go 1.26.1
- Update build/Dockerfile: golang:1.25.7 → golang:1.26.1

## CVEs Fixed

| Severity | CVE ID | Affected Component | Fix |
|----------|--------|--------------------|-----|
| HIGH | CVE-2026-25679 | stdlib v1.25.7 | Bump Go to 1.26.1 |
| MEDIUM | CVE-2026-27142 | stdlib v1.25.7 | Bump Go to 1.26.1 |
| LOW | CVE-2026-27139 | stdlib v1.25.7 | Bump Go to 1.26.1 |