### PR TITLE
[TEST, DO NOT REVIEW] cves: bump Go to 1.25.8 to fix CVE-2026-25679, CVE-2026-27142

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.25 as builder
+FROM docker.io/library/golang:1.25.8 as builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.25.5
+go 1.25.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Summary

Upgrade Go from 1.25.5 to 1.25.8 to fix stdlib CVEs.

This PR is for the `release-1.13.x` monorepo branch, which uses `eck-operator:2.11.1-tetrate-v10` (Go 1.25.5).

## CVEs Fixed

| CVE | Severity | Affected | Fix |
|-----|----------|----------|-----|
| CVE-2026-25679 | HIGH | stdlib v1.25.5 | Upgrade to Go 1.25.8 |
| CVE-2026-27142 | MEDIUM | stdlib v1.25.5 | Upgrade to Go 1.25.8 |

## Changes

- `go.mod`: go 1.25.5 → go 1.25.8
- `build/Dockerfile`: golang:1.25 → golang:1.25.8

## Image

The new Docker image `tetrate/eck-operator:2.11.1-tetrate-v13` will be built via the [build-eck-operator](https://github.com/tetrateio/skywalking-fork-sync/actions/workflows/build-eck-operator.yaml) workflow in skywalking-fork-sync.