### PR TITLE
cves: bump Go to 1.25.9 to fix stdlib CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.25.8 as builder
+FROM docker.io/library/golang:1.25.9 as builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.25.8
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Summary

Bumps Go toolchain from 1.25.8 to 1.25.9 to fix stdlib CVEs.

| CVE | Severity | Fixed In |
|-----|----------|----------|
| CVE-2026-32280 | HIGH | Go 1.25.9+ |
| CVE-2026-32281 | HIGH | Go 1.25.9+ |
| CVE-2026-32282 | HIGH | Go 1.25.9+ |
| CVE-2026-32283 | MEDIUM | Go 1.25.9+ |
| CVE-2026-32288 | MEDIUM | Go 1.25.9+ |
| CVE-2026-32289 | MEDIUM | Go 1.25.9+ |

## Changes

- `build/Dockerfile`: Updated Go version from `1.25.8` to `1.25.9`
- `go.mod`: Updated Go directive from `go 1.25.8` to `go 1.25.9`

## Image Build

The new Docker image `tetrate/eck-operator:2.11.1-tetrate-v14` is being built via the [build-eck-operator workflow](https://github.com/tetrateio/skywalking-fork-sync/actions/runs/24270060408).

Closes https://github.com/tetrateio/tetrate/issues/28337
Closes https://github.com/tetrateio/tetrate/issues/28366
Closes https://github.com/tetrateio/tetrate/issues/28368
Closes https://github.com/tetrateio/tetrate/issues/28378
Closes https://github.com/tetrateio/tetrate/issues/28380
Closes https://github.com/tetrateio/tetrate/issues/28384