### PR TITLE
cves: bump go to 1.26.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM docker.io/library/golang:1.26.4 as builder
+FROM docker.io/library/golang:1.26.5 as builder
 
 ARG VERSION
 ARG SHA1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.0

--- a/hack/helm/release/go.mod
+++ b/hack/helm/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-on-k8s/hack/helm/release
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Summary

Bump Go builder image from golang:1.26.4 to golang:1.26.5 in build/Dockerfile, and bump `go` directive in go.mod files to fix stdlib CVEs.

## CVEs Fixed

| CVE | Severity | Description | Fix |
|-----|----------|-------------|-----|
| CVE-2026-42505 | High | Go stdlib vulnerability | Upgrade Go toolchain to 1.26.5 |
| CVE-2026-39822 | High | Go stdlib vulnerability | Upgrade Go toolchain to 1.26.5 |

## Changes

- Bumped `go 1.26.4` → `go 1.26.5` in `go.mod` and `hack/helm/release/go.mod`
- Updated `build/Dockerfile` FROM golang:1.26.4 → golang:1.26.5

Related to tetrateio/tetrate#31967
Related to tetrateio/tetrate#31968
Related to tetrateio/tetrate#31970
Related to tetrateio/tetrate#31971
Related to tetrateio/tetrate#31973
Related to tetrateio/tetrate#31974